### PR TITLE
#5 feat(pipeline): implement temporal smoothing using previous frame fit

### DIFF
--- a/include/lane_detect.hpp
+++ b/include/lane_detect.hpp
@@ -12,6 +12,8 @@ struct LaneState {
     bool hasPrev = false;
     cv::Vec3d leftPrev;
     cv::Vec3d rightPrev;
+
+    double smoothingAlpha = 0.25;
 };
 
 LaneFit detectLane(const cv::Mat& warpedBinary, LaneState& state,

--- a/src/lane_detect.cpp
+++ b/src/lane_detect.cpp
@@ -129,12 +129,22 @@ LaneFit detectLane(const cv::Mat& warpedBinary, LaneState& state,
         return fit;
     }
 
-    fit.left = leftFit;
-    fit.right = rightFit;
+    cv::Vec3d smoothedLeft = leftFit;
+    cv::Vec3d smoothedRight = rightFit;
+
+    if (state.hasPrev) {
+        const double alpha = state.smoothingAlpha;
+
+        smoothedLeft = alpha * leftFit + (1.0 - alpha) * state.leftPrev;
+        smoothedRight = alpha * rightFit + (1.0 - alpha) * state.rightPrev;
+    }
+
+    fit.left = smoothedLeft;
+    fit.right = smoothedRight;
     fit.valid = true;
 
-    state.leftPrev = leftFit;
-    state.rightPrev = rightFit;
+    state.leftPrev = smoothedLeft;
+    state.rightPrev = smoothedRight;
     state.hasPrev = true;
 
     return fit;


### PR DESCRIPTION
Closes #5

## Changes
- Added a configurable smoothing factor to `LaneState`.
- Used the previous valid left/right polynomial fits when `LaneState::hasPrev` is true.
- Blended current lane fits with previous frame fits using a weighted average.
- Stored the smoothed fits back into `LaneState` for use by the next frame.

## Testing
- Confirmed `smoothingAlpha` is defined in `LaneState`.
- Confirmed `state.hasPrev`, `state.leftPrev`, and `state.rightPrev` are used during smoothing.
- Built the project successfully with CMake:
```bash
cmake -S . -B build
cmake --build build
```