### PR TITLE
#8 feat(pipeline): fall back to previous fit on detectLane failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Lane pixel detection and polynomial fitting are implemented in the function `det
 - collects all non-zero pixels using `cv::findNonZero`,
 - runs a vertical sliding-window scan (with parameters `nwindows`, `margin`, `minpix`) to accumulate left/right lane pixel coordinates and recenters each window based on the mean x-position of pixels found in the window,
 - fits a 2nd-order polynomial `x = A*y^2 + B*y + C` for the left and right lanes using the helper function `polyfit_x_of_y()` (also in `src/lane_detect.cpp`),
-- applies geometric sanity checks, including left/right lane ordering, minimum and maximum lane-width bounds, lane-width consistency across the image, and curvature-coefficient similarity between the two fitted lane lines.
+- applies geometric sanity checks, including left/right lane ordering, minimum and maximum lane-width bounds, lane-width consistency across the image, and curvature-coefficient similarity between the two fitted lane lines
+- falls back to the previous valid lane fit when the current frame fails validation, preventing a single bad frame from causing an immediate failure overlay in video output
 
 The lane detection stage is called from the main frame-processing function `processFrame()` in `src/pipeline.cpp`, which passes the warped binary image into `detectLane()` and then uses the fitted polynomials for lane visualization and further metrics.
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -66,6 +66,15 @@ cv::Mat processFrame(const cv::Mat& frame, PipelineState& state) {
     // detect lane
     LaneFit fit = detectLane(warped, state.laneState, 9, 100, 50);
 
+    bool usedFallback = false;
+
+    if (!fit.valid && state.laneState.hasPrev) {
+        fit.left = state.laneState.leftPrev;
+        fit.right = state.laneState.rightPrev;
+        fit.valid = true;
+        usedFallback = true;
+    }
+
     // prepare outputs for saving (only valid if fit.valid)
     cv::Mat laneWarp, laneUnwarped;
 
@@ -121,6 +130,11 @@ cv::Mat processFrame(const cv::Mat& frame, PipelineState& state) {
                     {40,40}, cv::FONT_HERSHEY_SIMPLEX, 1, {0,255,0}, 2);
         cv::putText(out, "Offset: " + std::to_string(offset_m) + " m",
                     {40,80}, cv::FONT_HERSHEY_SIMPLEX, 1, {0,255,0}, 2);
+
+        if (usedFallback) {
+            cv::putText(out, "Using previous lane fit", {40,120},
+            cv::FONT_HERSHEY_SIMPLEX, 0.8, {0,255,255}, 2);
+        }
     }
 
     // save intermediates per-image (only if output_dir is set)


### PR DESCRIPTION
Closes #8

## Changes
- Added fallback handling in `processFrame()` when `detectLane()` returns an invalid fit.
- Reused `LaneState::leftPrev` and `LaneState::rightPrev` when a previous valid lane fit exists.
- Kept the red `"Lane detection failed"` overlay only for cases where no previous fit is available.
- Added an optional `"Using previous lane fit"` overlay when fallback is active.
- Documented the pipeline-level fallback behavior in the README.

## Testing
- Built the project successfully with CMake:
```bash
cmake -S . -B build
cmake --build build
```