### PR TITLE
#13 docs(readme): add pipeline diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ The demo below shows the processed video output with the detected lane area, est
 
 The processing flow is:
 
-
-with this:
-
 ````md
 ```mermaid
 flowchart TD

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ flowchart TD
     Q --> R[Final lane overlay]
 ```
 
+The source for this diagram is also stored in [`docs/diagrams/pipeline.mmd`](docs/diagrams/pipeline.mmd).
+
 ## Camera Calibration
 
 Camera calibration is performed using multiple images of a chessboard pattern.

--- a/README.md
+++ b/README.md
@@ -31,18 +31,35 @@ The demo below shows the processed video output with the detected lane area, est
 
 The processing flow is:
 
-```text
-Input frame
-→ camera undistortion
-→ CLAHE illumination normalization
-→ color + gradient thresholding
-→ binary lane mask
-→ perspective transform
-→ sliding-window lane search
-→ polynomial fitting
-→ sanity checks + temporal smoothing
-→ curvature and offset estimation
-→ final lane overlay
+
+with this:
+
+````md
+```mermaid
+flowchart TD
+    A[Raw camera frame] --> B[Camera calibration data]
+    B --> C[Undistort frame]
+
+    C --> D[CLAHE illumination normalization]
+    D --> E[Color thresholding<br/>white + yellow lane masks]
+    D --> F[Sobel-x gradient thresholding]
+    E --> G[Combined binary lane mask]
+    F --> G
+
+    G --> H[Perspective transform<br/>bird's-eye view]
+    H --> I[Histogram + sliding-window search]
+    I --> J[Second-order polynomial lane fit]
+
+    J --> K{Geometric sanity checks}
+    K -- valid --> L[Temporal smoothing<br/>with previous valid fit]
+    K -- invalid + previous fit exists --> M[Fallback to previous lane fit]
+    K -- invalid + no previous fit --> N[Failure overlay]
+
+    L --> O[Curvature estimation]
+    M --> O
+    O --> P[Vehicle offset estimation]
+    P --> Q[Inverse perspective transform]
+    Q --> R[Final lane overlay]
 ```
 
 ## Camera Calibration

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The demo below shows the processed video output with the detected lane area, est
 
 The processing flow is:
 
-````md
 ```mermaid
 flowchart TD
     A[Raw camera frame] --> B[Camera calibration data]

--- a/docs/diagrams/pipeline.mmd
+++ b/docs/diagrams/pipeline.mmd
@@ -1,0 +1,24 @@
+flowchart TD
+    A[Raw camera frame] --> B[Camera calibration data]
+    B --> C[Undistort frame]
+
+    C --> D[CLAHE illumination normalization]
+    D --> E[Color thresholding<br/>white + yellow lane masks]
+    D --> F[Sobel-x gradient thresholding]
+    E --> G[Combined binary lane mask]
+    F --> G
+
+    G --> H[Perspective transform<br/>bird's-eye view]
+    H --> I[Histogram + sliding-window search]
+    I --> J[Second-order polynomial lane fit]
+
+    J --> K{Geometric sanity checks}
+    K -- valid --> L[Temporal smoothing<br/>with previous valid fit]
+    K -- invalid + previous fit exists --> M[Fallback to previous lane fit]
+    K -- invalid + no previous fit --> N[Failure overlay]
+
+    L --> O[Curvature estimation]
+    M --> O
+    O --> P[Vehicle offset estimation]
+    P --> Q[Inverse perspective transform]
+    Q --> R[Final lane overlay]


### PR DESCRIPTION
Closes #13

## Changes
- Added a Mermaid pipeline diagram to the README.
- Covered the full flow from raw frame to final lane overlay.
- Included calibration, undistortion, CLAHE normalization, thresholding, perspective transform, lane detection, polynomial fitting, sanity checks, temporal smoothing, fallback, curvature, offset, and overlay stages.
- Added the diagram source file under `docs/diagrams/pipeline.mmd`.

## Testing
- Confirmed the Mermaid diagram is embedded in the README.
- Confirmed the diagram source file exists at `docs/diagrams/pipeline.mmd`.
- Verified the diagram covers all major pipeline stages from input frame to final overlay.